### PR TITLE
Update logging step name for histogram

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const toMetricsReporter = (
 
     handleMetric('gauge', {
       conclusion: subject.conclusion,
-      namespace: [context.repo.repo, job.name, step?.name],
+      namespace: [context.repo.repo, job.name, step?.name ?? 'steps'],
       duration,
       tags,
     })
@@ -86,7 +86,7 @@ export const toMetricsReporter = (
     if (step) {
       handleMetric('histogram', {
         conclusion: subject.conclusion,
-        namespace: [context.repo.repo, job.name, 'steps'],
+        namespace: [context.repo.repo, job.name, step.name],
         duration,
         tags,
       })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const toMetricsReporter = (
 
     handleMetric('gauge', {
       conclusion: subject.conclusion,
-      namespace: [context.repo.repo, job.name, step?.name ?? 'steps'],
+      namespace: [context.repo.repo, job.name, step?.name],
       duration,
       tags,
     })


### PR DESCRIPTION
Right now its logging like: 

```
  (gauge) jupiter.build_app_www.run_actions_setup_node_v1: 1 [event_name:pull_request,conclusion:success]
  (gauge) jupiter_build_app_www_run_actions_setup_node_v1.success: 1 [event_name:pull_request,conclusion:success]
  (histogram) jupiter.build_app_www.steps: 1 [event_name:pull_request,conclusion:success]
  (histogram) jupiter_build_app_www_steps.success: 1 [event_name:pull_request,conclusion:success]
  (gauge) jupiter.build_app_www.get_yarn_cache_directory_path: 1 [event_name:pull_request,conclusion:success]
  (gauge) jupiter_build_app_www_get_yarn_cache_directory_path.success: 1 [event_name:pull_request,conclusion:success]
  (histogram) jupiter.build_app_www.steps: 1 [event_name:pull_request,conclusion:success]
  (histogram) jupiter_build_app_www_steps.success: 1 [event_name:pull_request,conclusion:success]
  (gauge) jupiter.build_app_www.run_actions_cache_v2: 46 [event_name:pull_request,conclusion:success]
  (gauge) jupiter_build_app_www_run_actions_cache_v2.success: 46 [event_name:pull_request,conclusion:success]
  (histogram) jupiter.build_app_www.steps: 46 [event_name:pull_request,conclusion:success]
  (histogram) jupiter_build_app_www_steps.success: 46 [event_name:pull_request,conclusion:success]
```

but that makes the histogram ones super wierd